### PR TITLE
Updated tests to get rid of depricated test methods.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "afairhurst",
   "license": "ISC",
   "name": "js-aprs-is",
-  "version": "1.0.4-beta.8",
+  "version": "1.0.4-beta.9",
   "homepage": "https://github.com/KD0NKS/js-aprs-is",
   "description": "NodeJs library for connecting to an APRS-IS server.",
   "repository": {

--- a/src/ISSocket.ts
+++ b/src/ISSocket.ts
@@ -58,7 +58,7 @@ export class ISSocket extends Socket {
             , public callsign: string = "N0CALL"
             , public passcode: number = -1
             , public filter?: string
-            , public appId: string = `IS.js ${process.env.npm_package_version}` // (appname and versionnum should not exceed 15 characters)
+            , public appId: string = `${process.title} ${process.env.npm_package_version}` // (appname and version num should not exceed 15 characters)
             ) {
         super();
 

--- a/test/IS.test.ts
+++ b/test/IS.test.ts
@@ -1,8 +1,6 @@
-import { equal } from 'assert';
 import * as net from 'net';
 import * as chai from 'chai';
 import { ISSocket } from '../src/ISSocket';
-import { version } from '../package.json';
 
 const expect = chai.expect;
 
@@ -16,7 +14,7 @@ describe('Tests for IS class', () => {
             expect(connection.callsign).to.equal('N0CALL');
             expect(connection.passcode).to.equal(-1);
             expect(connection.filter).to.be.undefined;
-            expect(connection.appId).to.equal(`IS.js ${version}`);
+            expect(connection.appId).to.equal(`${process.title} ${process.env.npm_package_version}`);
         });
 
         it('Should instantiate an IS connection with given host, port, callsign, and appId.  All other values should default.', () => {
@@ -58,7 +56,7 @@ describe('Tests for IS class', () => {
         it('Should return a user connection string with all default parameters and no filter.', () => {
             const connection = new ISSocket('aprs.server.com', 12345);
 
-            expect(connection.userLogin).to.equal(`user N0CALL pass -1 vers IS.js ${version}`);
+            expect(connection.userLogin).to.equal(`user N0CALL pass -1 vers ${process.title} ${process.env.npm_package_version}`);
         });
 
         it('Should return a user connection string where all parameters including filter are specified.', () => {
@@ -78,12 +76,12 @@ describe('Tests for IS class', () => {
         });
 
         it('Client should report not being connected to server.', function() {
-            equal(false, connection.isConnected());
+            expect(connection.isConnected()).to.equal(false);
         });
 
         it('Client should successfully connect to server.', function() {
             connection.on('connect', function() {
-                equal(true, connection.isConnected());
+                expect(connection.isConnected()).to.equal(true);
             });
 
             connection.connect();
@@ -91,7 +89,7 @@ describe('Tests for IS class', () => {
 
         it('Client should successfully disconnect from server.', function() {
             connection.on('disconnect', function() {
-                equal(false, connection.isConnected());
+                expect(connection.isConnected()).to.equal(true);
             });
 
             connection.disconnect();
@@ -113,12 +111,12 @@ describe('Tests for IS class', () => {
         });
 
         it('Client should report not being connected to server.', function() {
-            equal(false, connection.isConnected());
+            expect(connection.isConnected()).to.equal(false);
         });
 
         it('Client should successfully connect to server.', function() {
             connection.on('connect', function() {
-                equal(true, connection.isConnected());
+                expect(connection.isConnected()).to.equal(true);
             });
 
             connection.connect();
@@ -126,7 +124,7 @@ describe('Tests for IS class', () => {
 
         it('Client should successfully disconnect from server.', function() {
             connection.on('disconnect', function() {
-                equal(false, connection.isConnected());
+                expect(connection.isConnected()).to.equal(false);
             });
 
             connection.disconnect();
@@ -134,7 +132,7 @@ describe('Tests for IS class', () => {
 
         it('Client should successfully connect to server.', function() {
             connection.on('connect', function() {
-                equal(true, connection.isConnected());
+                expect(connection.isConnected()).to.equal(true);
             });
 
             connection.connect();


### PR DESCRIPTION
App id now relies on process running the application as a default value.