### PR TITLE
2022-12_NoDelayFix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "afairhurst",
   "license": "ISC",
   "name": "js-aprs-is",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "homepage": "https://github.com/KD0NKS/js-aprs-is",
   "description": "NodeJs library for connecting to an APRS-IS server.",
   "repository": {

--- a/src/ISSocket.ts
+++ b/src/ISSocket.ts
@@ -67,7 +67,7 @@ export class ISSocket extends Socket {
 
         this._bufferedData = '';
         this._isSocketConnected = false;
-        this.setNoDelay(true);
+        this.setNoDelay(false);   // If your client software is bidirectional (sends and receives), turn off the Nagle algorithm when connecting to APRS-IS as it can introduce significant delays (TCP_NODELAY).
 
         // TODO: Do we want to throw errors if the host, port, callsign, are null?
 


### PR DESCRIPTION
Update to default value of nodelay in socket per APRS-IS documentation "If your client software is bidirectional (sends and receives), turn off the Nagle algorithm when connecting to APRS-IS as it can introduce significant delays (TCP_NODELAY)."